### PR TITLE
Revert ".github/workflows: Migrate workflows to Blacksmith runners"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   test_powershell:
     name: WindowsPowerShell
-    runs-on: blacksmith-4vcpu-windows-2025
+    runs-on: windows-latest
     steps:
       - name: Checkout Bucket
         uses: actions/checkout@main
@@ -35,7 +35,7 @@ jobs:
           .\personal-scoop\bin\test.ps1
   test_pwsh:
     name: PowerShell
-    runs-on: blacksmith-4vcpu-windows-2025
+    runs-on: windows-latest
     steps:
       - name: Checkout Bucket
         uses: actions/checkout@main

--- a/.github/workflows/excavator.yml
+++ b/.github/workflows/excavator.yml
@@ -10,7 +10,7 @@ name: Excavator
 jobs:
   excavate:
     name: Excavator
-    runs-on: blacksmith-4vcpu-windows-2025
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@main
       - name: Excavator

--- a/.github/workflows/issue_comment.yml
+++ b/.github/workflows/issue_comment.yml
@@ -5,7 +5,7 @@ name: Commented Pull Request
 jobs:
   pullRequestHandler:
     name: Pull Request Validator
-    runs-on: blacksmith-4vcpu-windows-2025
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@main
       - name: Pull Request Validator

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -5,7 +5,7 @@ name: Issue
 jobs:
   issueHandler:
     name: Issue Handler
-    runs-on: blacksmith-4vcpu-windows-2025
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@main
       - name: Issue Handler

--- a/.github/workflows/maintain-readme.yml
+++ b/.github/workflows/maintain-readme.yml
@@ -9,7 +9,7 @@ name: Readme Maintenance
 jobs:
   update-readme:
     name: Update Readme
-    runs-on: blacksmith-4vcpu-windows-2025
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@main
       - name: Update Readme

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -5,7 +5,7 @@ name: Pull Requests
 jobs:
   pullRequestHandler:
     name: Pull Request Validator
-    runs-on: blacksmith-4vcpu-windows-2025
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@main
       - name: Pull Request Validator


### PR DESCRIPTION
Reverts winpax/bucket#6

negligible performance increases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to standardize Windows runner configurations across continuous integration, pull request validation, issue automation, and maintenance jobs. All workflows now utilize standard GitHub-hosted runners for consistent execution environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->